### PR TITLE
Add admin mode with teacher authentication

### DIFF
--- a/src/static/index.html
+++ b/src/static/index.html
@@ -8,8 +8,13 @@
   </head>
   <body>
     <header>
-      <h1>Mergington High School</h1>
-      <h2>Extracurricular Activities</h2>
+      <div class="header-top">
+        <div>
+          <h1>Mergington High School</h1>
+          <h2>Extracurricular Activities</h2>
+        </div>
+        <button id="user-btn" class="user-btn" title="Teacher Login">👤</button>
+      </div>
     </header>
 
     <main>
@@ -40,6 +45,26 @@
         <div id="message" class="hidden"></div>
       </section>
     </main>
+
+    <!-- Login Modal -->
+    <div id="login-modal" class="modal hidden">
+      <div class="modal-content">
+        <span class="close">&times;</span>
+        <h3>Teacher Login</h3>
+        <form id="login-form">
+          <div class="form-group">
+            <label for="teacher-username">Username:</label>
+            <input type="text" id="teacher-username" required />
+          </div>
+          <div class="form-group">
+            <label for="teacher-password">Password:</label>
+            <input type="password" id="teacher-password" required />
+          </div>
+          <button type="submit">Login</button>
+        </form>
+        <div id="login-message" class="hidden"></div>
+      </div>
+    </div>
 
     <footer>
       <p>&copy; 2023 Mergington High School</p>

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -28,6 +28,35 @@ header h1 {
   margin-bottom: 10px;
 }
 
+.header-top {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0 20px;
+}
+
+.user-btn {
+  background-color: #fff;
+  color: #1a237e;
+  border: 2px solid #1a237e;
+  padding: 8px 12px;
+  font-size: 20px;
+  border-radius: 50%;
+  cursor: pointer;
+  width: 45px;
+  height: 45px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.2s;
+}
+
+.user-btn:hover {
+  background-color: #3949ab;
+  color: white;
+  border-color: white;
+}
+
 main {
   display: flex;
   flex-wrap: wrap;
@@ -197,4 +226,46 @@ footer {
   margin-top: 30px;
   padding: 20px;
   color: #666;
+}
+
+/* Modal Styles */
+.modal {
+  position: fixed;
+  z-index: 1000;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.modal-content {
+  background-color: white;
+  padding: 30px;
+  border-radius: 8px;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
+  width: 90%;
+  max-width: 400px;
+}
+
+.modal-content h3 {
+  margin-bottom: 20px;
+  color: #1a237e;
+  text-align: center;
+}
+
+.close {
+  color: #aaa;
+  float: right;
+  font-size: 28px;
+  font-weight: bold;
+  cursor: pointer;
+  transition: color 0.2s;
+}
+
+.close:hover {
+  color: #000;
 }

--- a/src/teachers.json
+++ b/src/teachers.json
@@ -1,0 +1,16 @@
+{
+  "teachers": [
+    {
+      "username": "mr_smith",
+      "password": "teacher123"
+    },
+    {
+      "username": "ms_johnson",
+      "password": "teacher456"
+    },
+    {
+      "username": "mr_williams",
+      "password": "teacher789"
+    }
+  ]
+}


### PR DESCRIPTION
## Problem
Students were removing each other from activities to free up space for themselves. We needed a way to restrict unregister permissions to teachers only.

## Solution
Implemented a teacher authentication system that:
- Allows teachers to log in via a user icon button in the header
- Restricts student removal to authenticated teachers only
- Hides delete buttons from non-authenticated users
- Stores teacher credentials in a `teachers.json` file

## Changes
- **Backend**: Added `/auth/login` endpoint and modified `/unregister` to require teacher authentication
- **Frontend**: Added login modal, user authentication state management, and conditional UI rendering
- **Security**: Delete buttons only appear for logged-in teachers
- **Credentials**: Sample teacher accounts provided (Mr. Smith, Ms. Johnson, Mr. Williams)

## How to Test
1. Run the application
2. Click the user icon (👤) in the top-right corner
3. Log in with credentials: `mr_smith` / `teacher123`
4. The icon changes to a green checkmark (✓)
5. Delete buttons (❌) now appear next to student names
6. Teachers can remove students; students cannot

Closes #5